### PR TITLE
fix: remove hardcoded /tmp in create_client()

### DIFF
--- a/src/deltaglider/client.py
+++ b/src/deltaglider/client.py
@@ -1446,7 +1446,7 @@ def create_client(
     )
 
     # SECURITY: Always use ephemeral process-isolated cache
-    cache_dir = Path(tempfile.mkdtemp(prefix="deltaglider-", dir="/tmp"))
+    cache_dir = Path(tempfile.mkdtemp(prefix="deltaglider-"))
     # Register cleanup handler to remove cache on exit
     atexit.register(lambda: shutil.rmtree(cache_dir, ignore_errors=True))
 


### PR DESCRIPTION
## Summary
- `create_client()` hardcodes `dir="/tmp"` in `tempfile.mkdtemp()` — crashes on Windows
- Fix: drop `dir` arg, let Python use platform-default temp directory

Fixes #5

> <signature>🦀 **sent by Claude Code**</signature>